### PR TITLE
Debug the translation menu

### DIFF
--- a/assets/translation-lab-language-dropdown.css
+++ b/assets/translation-lab-language-dropdown.css
@@ -105,7 +105,7 @@
 }
 
 .translation-lab-language-options .language-option.active {
-  border-bottom: 1px solid;
+  border-bottom: 0px solid;
 }
 
 .translation-lab-language-options .language-option:hover {


### PR DESCRIPTION
Make the border-bottom in the translation tab's dropdown menu to become invisible. 